### PR TITLE
fix(deps): patch all open Dependabot alerts (aws-lc-sys 0.33.0 → 0.42.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932a7d9d28b0d2ea34c6b3779d35e3dd6f6345317c34e73438c4f1f29144151"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -109,15 +109,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.33.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826f2e4cfc2cd19ee53c42fbf68e2f81ec21108e0b7ecf6a71cf062137360fc"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -219,26 +219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,15 +311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,17 +332,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -914,12 +874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,15 +1199,6 @@ checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
  "mach2",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1797,6 +1742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,7 +1840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1909,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -2063,7 +2014,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.0",
  "indoc",
- "itertools 0.14.0",
+ "itertools",
  "kasuari",
  "lru",
  "strum",
@@ -2115,7 +2066,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "indoc",
  "instability",
- "itertools 0.14.0",
+ "itertools",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -2199,12 +2150,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3080,7 +3025,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width",
 ]


### PR DESCRIPTION
## Summary

All five open Dependabot security alerts on this repo point at the same transitive dependency: **`aws-lc-sys`** (the AWS-LC crypto library used by `rustls` via `aws-lc-rs`). This PR resolves all of them with a single lockfile update — no source or manifest changes needed.

`cargo update -p aws-lc-rs`: **aws-lc-rs 1.15.0 → 1.17.1**, which moves **aws-lc-sys 0.33.0 → 0.42.0** (every advisory below is patched as of 0.38.0/0.39.0).

## Alerts resolved

| Alert | Advisory | Severity | Issue | Patched in |
|---|---|---|---|---|
| [#9](https://github.com/jasonwitty/socktop/security/dependabot/9) | [GHSA-9f94-5g5w-gf6r](https://github.com/advisories/GHSA-9f94-5g5w-gf6r) | High | CRL Distribution Point scope check logic error | 0.39.0 |
| [#8](https://github.com/jasonwitty/socktop/security/dependabot/8) | [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3) | High | X.509 name constraints bypass via wildcard/Unicode CN | 0.39.0 |
| [#7](https://github.com/jasonwitty/socktop/security/dependabot/7) | [GHSA-hfpc-8r3f-gw53](https://github.com/advisories/GHSA-hfpc-8r3f-gw53) | High | PKCS7_verify signature validation bypass | 0.38.0 |
| [#6](https://github.com/jasonwitty/socktop/security/dependabot/6) | [GHSA-65p9-r9h6-22vj](https://github.com/advisories/GHSA-65p9-r9h6-22vj) | High | Timing side-channel in AES-CCM tag verification | 0.38.0 |
| [#5](https://github.com/jasonwitty/socktop/security/dependabot/5) | [GHSA-vw5v-4f2q-w9xf](https://github.com/advisories/GHSA-vw5v-4f2q-w9xf) | High | PKCS7_verify certificate chain validation bypass | 0.38.0 |

## Notes

- A plain `cargo update -p aws-lc-sys` could not fix this: aws-lc-rs 1.15.0 pins aws-lc-sys to 0.33.x, so the parent crate had to be bumped (still semver-compatible, 1.x).
- Side effect of the bump: aws-lc-sys 0.42 no longer needs bindgen at build time, so `bindgen`, `cexpr`, `clang-sys`, `glob`, and `itertools` drop out of the lockfile and `pkg-config` is added — hence the net −55 lines.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo test --workspace` — all 17 test suites pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)