### PR TITLE
fix(ci): pin deb builds to ubuntu-22.04 and enforce the fleet glibc floor

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -174,7 +174,7 @@ jobs:
           FLOOR="2.36"
           fail=0
           for deb in debs/*.deb; do
-            req=$(dpkg-deb -f "$deb" Depends | grep -oE 'libc6 \(>= [0-9.]+\)' | grep -oE '[0-9.]+' || true)
+            req=$(dpkg-deb -f "$deb" Depends | sed -n 's/.*libc6 (>= \([0-9.]*\)).*/\1/p' | head -1)
             echo "$deb -> libc6 >= ${req:-none}"
             if [ -n "$req" ] && [ "$(printf '%s\n' "$req" "$FLOOR" | sort -V | tail -1)" != "$FLOOR" ]; then
               echo "::error::$deb requires libc6 >= $req, exceeding the fleet floor $FLOOR (bookworm). The build runner's glibc is too new — see the runs-on pin comment."

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -18,7 +18,15 @@ env:
 jobs:
   build-deb:
     name: Build .deb for ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    # PINNED, not ubuntu-latest: the binaries link against this runner's
+    # (multiarch) glibc, so the runner sets the MINIMUM glibc the .debs demand
+    # at install time. ubuntu-latest moved to 24.04/glibc 2.39 and the packages
+    # stopped installing on Debian 12/RPi OS bookworm (glibc 2.36). 22.04 links
+    # 2.35, which bookworm satisfies. The "enforce glibc floor" step below
+    # turns any future violation into a red build instead of a fleet-wide apt
+    # failure — if this pin ever has to move past bookworm's glibc, that step
+    # is the contract to renegotiate first.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -158,6 +166,22 @@ jobs:
         run: |
           mkdir -p debs
           cp target/${{ matrix.target }}/debian/*.deb debs/
+
+      - name: Enforce glibc floor (Debian 12 / RPi OS bookworm fleet)
+        run: |
+          # The fleet's oldest supported glibc. A .deb that demands newer libc6
+          # than this will not install on the Pis — fail HERE, not at apt time.
+          FLOOR="2.36"
+          fail=0
+          for deb in debs/*.deb; do
+            req=$(dpkg-deb -f "$deb" Depends | grep -oE 'libc6 \(>= [0-9.]+\)' | grep -oE '[0-9.]+' || true)
+            echo "$deb -> libc6 >= ${req:-none}"
+            if [ -n "$req" ] && [ "$(printf '%s\n' "$req" "$FLOOR" | sort -V | tail -1)" != "$FLOOR" ]; then
+              echo "::error::$deb requires libc6 >= $req, exceeding the fleet floor $FLOOR (bookworm). The build runner's glibc is too new — see the runs-on pin comment."
+              fail=1
+            fi
+          done
+          exit $fail
 
       - name: List generated packages
         run: ls -lh debs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 1.60.0 — unreleased
+## 1.60.1 — unreleased
 
-Everything since `v1.50.0`. Applies to all three crates (`socktop`, `socktop_agent`, `socktop_connector`), which move to 1.60.0 together.
+Identical to 1.60.0 plus rebuilt Debian packages: the 1.60.0 debs were linked
+against glibc 2.39 (a GitHub runner migration) and would not install on
+Debian 12 / Raspberry Pi OS bookworm. CI now pins the build environment and
+gates every package against the fleet's glibc floor. 1.60.0 was never
+published to crates.io.
+
+Everything since `v1.50.0`. Applies to all three crates (`socktop`, `socktop_agent`, `socktop_connector`), which move to 1.60.1 together.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "socktop"
-version = "1.60.0"
+version = "1.60.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "socktop_agent"
-version = "1.60.0"
+version = "1.60.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "socktop_connector"
-version = "1.60.0"
+version = "1.60.1"
 dependencies = [
  "flate2",
  "futures-util",

--- a/socktop/Cargo.toml
+++ b/socktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socktop"
-version = "1.60.0"
+version = "1.60.1"
 authors = ["Jason Witty <jasonpwitty+socktop@proton.me>"]
 description = "Remote system monitor over WebSocket, TUI like top"
 edition = "2024"
@@ -11,7 +11,7 @@ repository = "https://github.com/jasonwitty/socktop"
 
 [dependencies]
 # socktop connector for agent communication
-socktop_connector = { version = "1.60.0", path = "../socktop_connector" }
+socktop_connector = { version = "1.60.1", path = "../socktop_connector" }
 
 tokio = { workspace = true }
 futures-util = { workspace = true }

--- a/socktop_agent/Cargo.toml
+++ b/socktop_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socktop_agent"
-version = "1.60.0"
+version = "1.60.1"
 authors = ["Jason Witty <jasonpwitty+socktop@proton.me>"]
 description = "Socktop agent daemon. Serves host metrics over WebSocket."
 edition = "2024"

--- a/socktop_connector/Cargo.toml
+++ b/socktop_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socktop_connector"
-version = "1.60.0"
+version = "1.60.1"
 edition = "2024"
 license = "MIT"
 description = "WebSocket connector library for socktop agent communication"


### PR DESCRIPTION
The v1.60.0 debs demand `libc6 (>= 2.39)` and fail to install on Raspberry Pi OS / Debian 12 bookworm (glibc 2.36).

**Root cause:** the cross-compiled binaries link against the build **runner's** multiarch glibc, so the runner determines the minimum glibc at install time. `ubuntu-latest` migrated 22.04 → 24.04 (glibc 2.35 → 2.39) between the 1.50.x releases and this one.

**Fix:**
1. Pin the `build-deb` job to `ubuntu-22.04` (glibc 2.35 ≤ bookworm's 2.36) — restores the environment the 1.50.x debs were built in.
2. New **enforce-glibc-floor** step: reads each built .deb's computed `libc6` requirement and fails the run if it exceeds 2.36 — so the *next* silent runner migration (22.04 retires ~2027) becomes a red build with a pointed error instead of fleet-wide apt breakage. Comparison logic unit-checked (2.34 ok / 2.36 ok / 2.39 fail).

This PR itself exercises the full fix: the PR trigger builds all four targets, and the new gate must pass on every produced package.

**After merge**, re-cutting v1.60.0 (delete tag + release, re-tag on master) rebuilds and republishes the debs with the correct floor — nothing has consumed the broken ones, and cargo isn't published yet, so the version can stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)